### PR TITLE
Fixed initialisation of underwater-mod.

### DIFF
--- a/colors/underwater-mod.vim
+++ b/colors/underwater-mod.vim
@@ -6,14 +6,12 @@
 " To use custom tabline, add to .gvimrc:
 "   let g:mgutz_tabline=1
 
-let colors_name="underwater-mod"
-
 set background=dark
 hi clear
-
 if exists("syntax_on")
     syntax reset
 endif
+let colors_name="underwater-mod"
 
 if version >= 700
     hi CursorLine       guibg=#18374F


### PR DESCRIPTION
The theme would **not** load at Vim startup. It would only work with manually typing `colorscheme underwater-mod` in MacVim.
